### PR TITLE
[Fix] Update Netlify Deployment Token & Image Path Consistency

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ jobs:
         uses: nwtgck/actions-netlify@v3.0
         with:
           publish-dir: './dist'
-          production-deploy: false
+          github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           deploy-message: '🚀 Auto Deployment for Staging - ${{ github.sha }}'
           github-deployment-environment: staging
         env:

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -4,7 +4,7 @@ const RESTO_IMG_SMALL = `${BASE_API_URL}/images/small`;
 const RESTO_IMG_MEDIUM = `${BASE_API_URL}/images/medium`;
 const RESTO_IMG_LARGE = `${BASE_API_URL}/images/large`;
 
-const DEFAULT_PREVIEW_IMG = 'https://cooknify.netlify.app/restaurant-catalog-preview.jpg';
+const DEFAULT_PREVIEW_IMG = 'https://cooknify.netlify.app/public/restaurant-catalog-preview.jpg';
 
 const API_ENPOINTS = {
   RESTO_LIST: `${BASE_API_URL}/list`,

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -29,7 +29,7 @@
     <meta property="og:description" content="Browse and review top restaurants on CookNify." />
     <meta
       property="og:image"
-      content="https://cooknify.netlify.app/restaurant-catalog-preview.jpg"
+      content="https://cooknify.netlify.app/public/restaurant-catalog-preview.jpg"
     />
     <meta property="og:url" content="https://cooknify.netlify.app/" />
     <meta property="og:type" content="website" />
@@ -45,7 +45,7 @@
     />
     <meta
       name="twitter:image"
-      content="https://cooknify.netlify.app/restaurant-catalog-preview.jpg"
+      content="https://cooknify.netlify.app/public/restaurant-catalog-preview.jpg"
     />
 
     <!-- PWA / Icons -->


### PR DESCRIPTION
This pull request includes the following fixes:

1. Netlify Staging Deployment Fix
    Replaced the default token with a personal access token to fix deployment issues on the staging environment.

2. Image URL Update
    Updated image URLs across the codebase to explicitly include the 'public' path for consistency and to avoid missing assets during builds.